### PR TITLE
[bugfix/wv-131]<fixed twitter login button unresponsive after hitting back button>TEAM REVIEW 

### DIFF
--- a/src/js/common/components/CampaignSupport/MostRecentCampaignSupport.jsx
+++ b/src/js/common/components/CampaignSupport/MostRecentCampaignSupport.jsx
@@ -270,9 +270,9 @@ class MostRecentCampaignSupport extends React.Component {
             {supportersOnStageNow.map((comment) => (
               <CommentWrapper className="comment" key={comment.id}>
                 <CommentVoterPhotoWrapper>
-                  {comment.we_vote_hosted_profile_image_url_tiny ? (
+                  {comment.we_vote_hosted_profile_image_url_medium ? (
                     <LazyImage
-                      src={comment.we_vote_hosted_profile_image_url_tiny}
+                      src={comment.we_vote_hosted_profile_image_url_medium}
                       placeholder={avatarGeneric()}
                       className="profile-photo"
                       height={48}

--- a/src/js/components/Ballot/SelectBallotModal.jsx
+++ b/src/js/components/Ballot/SelectBallotModal.jsx
@@ -151,7 +151,7 @@ class SelectBallotModal extends Component {
                   </ToggleGroup>
                   <StateDropDownCore
                     stateCodesToDisplay={[]}
-                    handleChooseStateChange={this.handleChooseStateChange}
+                    onStateDropDownChange={this.handleChooseStateChange}
                     stateCodesHtml=""
                     selectedState={this.state.selectedState}
                     dialogLabel="Which State?"


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

After redirecting to Twitter login and then hitting back button, user is returned to sign in options panel with Twitter button disabled. This issue occurs consistently in Safari and only occasionally in Chrome when other factors are present.

### Changes included this pull request?

At line 138 set state twitterSignInStartSubmitted: true only if isIOS. This prevents disabled from being set to true in line 187